### PR TITLE
Modernize: Various version bumps for Seven Things

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,8 @@ libraryDependencies ++= {
   Seq(
     "net.liftweb" %% "lift-webkit" % liftVersion,
     "net.liftweb" %% "lift-wizard" % liftVersion,
-    "org.mortbay.jetty" % "jetty" % "6.1.22" % "container; test",
+    "javax.servlet"     %  "servlet-api"        % "2.5" % "provided",
+    "org.eclipse.jetty" % "jetty-webapp"        % "9.2.3.v20140905"  % "compile,container",
     "junit" % "junit" % "4.10" % "test",
     "ch.qos.logback" % "logback-classic" % "1.0.6",
     "org.specs2" %% "specs2-core" % "3.5" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,11 @@ name := "seventhings"
 
 version := "0.3"
 
-scalaVersion := "2.9.1"
+scalaVersion := "2.11.6"
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
+
+resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 libraryDependencies ++= {
   val liftVersion = "2.6"
@@ -18,7 +20,7 @@ libraryDependencies ++= {
     "org.mortbay.jetty" % "jetty" % "6.1.22" % "container; test",
     "junit" % "junit" % "4.10" % "test",
     "ch.qos.logback" % "logback-classic" % "1.0.6",
-    "org.specs2" %% "specs2" % "1.11" % "test",
+    "org.specs2" %% "specs2-core" % "3.5" % "test",
     "com.h2database" % "h2" % "1.3.167"
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalacOptions ++= Seq("-deprecation", "-unchecked")
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 libraryDependencies ++= {
-  val liftVersion = "2.6"
+  val liftVersion = "2.6.2"
   Seq(
     "net.liftweb" %% "lift-webkit" % liftVersion,
     "net.liftweb" %% "lift-wizard" % liftVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,7 @@
 resolvers += "Web plugin repo" at "http://siasia.github.com/maven2"
 
-libraryDependencies <+= sbtVersion(v => v match {
-case "0.11.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.0-0.2.8"
-case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
-case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.11"
-case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-})
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.9.0")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0-RC1")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.0.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")

--- a/src/test/scala/code/XmlSourceSpecs.scala
+++ b/src/test/scala/code/XmlSourceSpecs.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable._
 import net.liftweb.common.Full
 import net.liftweb.util.PCDataXmlParser
 
-class XmlSourceSpecs extends SpecificationWithJUnit {
+class XmlSourceSpecs extends Specification {
 
   "XML Sources" should {
     "be well-formed" in {


### PR DESCRIPTION
While preparing a talk on Lift I noticed that the Seven Things site could use some version bumps. So I went in and made some changes. There are a few things that are outstanding here. Specifically:

- [ ] The tests don't seem to pass. They don't seem particularly useful? Should we chuck them or...?
- [ ] I upgraded sbt since 0.11 won't run on Java 8 which more and more people are going to be switching to. We still have the old sbt-launch.jar in the repo but I'd like of like to nuke it altogether. Homebrew builds for sbt have gotten more reliable in recent days. Is there any value to having it?